### PR TITLE
fix(root): Enforce a space between selector and the curly brace.

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ module.exports = {
         ]
       }
     ],
+    "block-opening-brace-space-before": "always",
     "block-closing-brace-newline-before": "always",
     "block-no-empty": true,
     "block-opening-brace-newline-after": "always",


### PR DESCRIPTION
Related issue: [#5](https://github.com/Hipo/stylelint-config-hipo-base/issues/5)