### PR TITLE
fix(root): Ignore "after-comment" for "declaration-empty-line-before".

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,8 @@ module.exports = {
           "first-nested"
         ],
         "ignore": [
-          "after-declaration"
+          "after-declaration",
+          "after-comment"
         ]
       }
     ],


### PR DESCRIPTION
Related issue: [#4](https://github.com/Hipo/stylelint-config-hipo-base/issues/4)