### PR TITLE
fix(root): "first-nested" exception for "comment-empty-line-before" rule.

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ module.exports = {
     "comment-empty-line-before": [
       "always",
       {
+        "except": ["first-nested"],
         "ignore": [
           "after-comment",
           "stylelint-commands"


### PR DESCRIPTION
Related issue: [#3](https://github.com/Hipo/stylelint-config-hipo-base/issues/3)