### PR TITLE
fix: Make `always-single-line` for `colon-space-after`

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = {
     "declaration-block-semicolon-space-before": "never",
     "declaration-block-single-line-max-declarations": 1,
     "declaration-block-trailing-semicolon": "always",
-    "declaration-colon-space-after": "always",
+    "declaration-colon-space-after": "always-single-line",
     "declaration-colon-space-before": "never",
     "declaration-empty-line-before": [
       "always",


### PR DESCRIPTION
Related issue: https://github.com/Hipo/stylelint-config-hipo-base/issues/18